### PR TITLE
Allow slashes for station_id and region + handle 912ff codes for The Netherlands

### DIFF
--- a/pymetdecoder/synop/__init__.py
+++ b/pymetdecoder/synop/__init__.py
@@ -938,11 +938,6 @@ class SYNOP(pymetdecoder.Report):
                         measure_period = { "value": 10, "unit": "min" }
                     ))
                 elif j[2] == "1":
-                    # try:
-                    #     time_before = time_before_obs
-                    # except Exception:
-                    #     time_before = def_time_before
-                    # Check for direction
                     parse = [g]
                     try:
                         if group_9[idx + 1].startswith("915"):
@@ -956,6 +951,13 @@ class SYNOP(pymetdecoder.Report):
                     data["highest_gust"].append(obs.HighestGust().decode(" ".join(parse),
                         unit = data["wind_indicator"]["unit"] if data["wind_indicator"] is not None else None,
                         time_before = time_before_obs
+                    ))
+                elif j[2] == "2":
+                    if "highest_gust" not in data:
+                        data["highest_gust"] = []
+                    data["highest_gust"].append(obs.HighestGust().decode(g,
+                        unit = data["wind_indicator"]["unit"] if data["wind_indicator"] is not None else None,
+                        measure_period = { "value": 10, "unit": "min" }
                     ))
                 else:
                     self.handle_not_implemented(g)

--- a/pymetdecoder/synop/__init__.py
+++ b/pymetdecoder/synop/__init__.py
@@ -64,7 +64,7 @@ class SYNOP(pymetdecoder.Report):
             # Now add the station ID if it is an AAXX station. Otherwise, add the current position
             if data["station_type"]["value"] == "AAXX":
                 group = next(groups)
-                if not self._is_valid_group(group, allowSlashes=False):
+                if not self._is_valid_group(group):
                     raise pymetdecoder.DecodeError("{} is an invalid IIiii group".format(group))
                 data["station_id"] = obs.StationID().decode(group)
                 data["region"]     = obs.Region().decode(group)


### PR DESCRIPTION
Some SYNOP messages are only missing station_id and region information, for example:

"AAXX 26011 ///// 46978 00401 10191 20167 30127 40130 58006 333 91003 91104 91202="

This message currently results in a DecodeError while the remaining fields still contain usable data. By the following change these type of messages can also be parsed and let it up to the user to decide how to handle None values for station_id and region.